### PR TITLE
Suggestion for option to define the order of screens

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   },
   "screens": {
     "clock": "screens/clock",
-    "agenda": "screens/agenda"
+    "agenda": "screens/agenda",
     "energenie": "screens/energenie",
     "finlandarrivals": "screens/finlandarrivals",
     "football": "screens/football",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,12 @@
-{"webserver": {
+{
+  "webserver": {
     "enabled": true,
     "webport": 8088,
     "apiport": 8089
-    }
+  },
+  "screens": {
+    "weather": "screens/weather",
+    "clock": "screens/clock",
+    "wordclock": "screens/wordclock"
+  }
 }

--- a/config.json
+++ b/config.json
@@ -5,8 +5,21 @@
     "apiport": 8089
   },
   "screens": {
-    "weather": "screens/weather",
     "clock": "screens/clock",
+    "agenda": "screens/agenda"
+    "energenie": "screens/energenie",
+    "finlandarrivals": "screens/finlandarrivals",
+    "football": "screens/football",
+    "londonbus": "screens/londonbus",
+    "mythtv": "screens/mythtv",
+    "photoalbum": "screens/photoalbum",
+    "pong": "screens/pong",
+    "squeezeplayer": "screens/squeezeplayer",
+    "template": "screens/template",
+    "trains": "screens/trains",
+    "tube": "screens/tube",
+    "xmas": "screens/xmas",
+    "weather": "screens/weather",
     "wordclock": "screens/wordclock"
   }
 }

--- a/core/getplugins.py
+++ b/core/getplugins.py
@@ -1,9 +1,9 @@
+import collections
 import imp
-import os
 import json
+import os
 
-# Constants that are used to find plugins
-PluginFolder = "./screens"
+PluginConfig = "./config.json"
 PluginScript = "screen.py"
 ScreenConf = "conf.json"
 
@@ -12,16 +12,18 @@ def getPlugins(inactive=False):
     plugins = []
     a = 1
 
-    # Get the contents of the plugin folder
-    possibleplugins = os.listdir(PluginFolder)
+    # Load in the config.json file in the root directory
+    conf = json.load(open(os.path.join(PluginConfig)), object_pairs_hook=collections.OrderedDict)
 
-    # Loop over it
-    for i in possibleplugins:
-        location = os.path.join(PluginFolder, i)
+    # Get the screens in the json file
+    screens = conf.get("screens")
+
+    # Loop over the screens and get their name and location
+    for name, location in screens.items():
 
         # Ignore anything that doesn't meet our criteria
         if (not os.path.isdir(location) or PluginScript not in
-                                           os.listdir(location)):
+            os.listdir(location)):
             continue
 
         # Load the module info into a variavls
@@ -46,7 +48,7 @@ def getPlugins(inactive=False):
                     web = None
 
                 # Custom dict for the plugin
-                plugin = {"name": i,
+                plugin = {"name": name,
                           "info": inf,
                           "id": a,
                           "screen": conf["screen"],


### PR DESCRIPTION
Just a pull request for a order of screen option. 
I thought of defining the order in the config.json in the root folder. Changed the getplugins file so it scans the json and uses the values to read the plugins in the right order.

I'm still using the enable parameter for each screen. So you can still turn off screens.

Again, it is just a suggestion. Let me know what you think


 [Not yet fully tested]